### PR TITLE
[DB] S2 PR-02: db/rls-jobhistory-job-dept — Same RLS policy pattern for jobHistory, job, department

### DIFF
--- a/S2 PR-02/RLS policy pattern for jobHistory, job, department
+++ b/S2 PR-02/RLS policy pattern for jobHistory, job, department
@@ -1,0 +1,235 @@
+-- ============================================
+-- PR-02: RLS Policies for jobHistory, job, and department
+-- ============================================
+
+-- ============================================
+-- JOB HISTORY TABLE Policies
+-- ============================================
+
+-- Drop existing policies if any
+DROP POLICY IF EXISTS "jobHistory_select_policy" ON jobHistory;
+DROP POLICY IF EXISTS "jobHistory_insert_policy" ON jobHistory;
+DROP POLICY IF EXISTS "jobHistory_update_edit_policy" ON jobHistory;
+DROP POLICY IF EXISTS "jobHistory_update_deactivate_policy" ON jobHistory;
+DROP POLICY IF EXISTS "jobHistory_update_recover_policy" ON jobHistory;
+
+-- 1. SELECT policy
+CREATE POLICY "jobHistory_select_policy" ON jobHistory
+    FOR SELECT
+    USING (
+        record_status = 'ACTIVE' 
+        OR 
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    );
+
+-- 2. INSERT policy (requires JH_ADD)
+CREATE POLICY "jobHistory_insert_policy" ON jobHistory
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JH_ADD' 
+            AND right_value = 1
+        )
+    );
+
+-- 3. UPDATE-edit policy (requires JH_EDIT)
+CREATE POLICY "jobHistory_update_edit_policy" ON jobHistory
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JH_EDIT' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JH_EDIT' 
+            AND right_value = 1
+        )
+    );
+
+-- 4. UPDATE-deactivate policy (requires JH_DEL)
+CREATE POLICY "jobHistory_update_deactivate_policy" ON jobHistory
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JH_DEL' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        record_status = 'INACTIVE'
+    );
+
+-- 5. UPDATE-recover policy (ADMIN/SUPERADMIN only)
+CREATE POLICY "jobHistory_update_recover_policy" ON jobHistory
+    FOR UPDATE
+    USING (
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    )
+    WITH CHECK (
+        record_status = 'ACTIVE'
+    );
+
+-- ============================================
+-- JOB TABLE Policies
+-- ============================================
+
+-- Drop existing policies if any
+DROP POLICY IF EXISTS "job_select_policy" ON job;
+DROP POLICY IF EXISTS "job_insert_policy" ON job;
+DROP POLICY IF EXISTS "job_update_edit_policy" ON job;
+DROP POLICY IF EXISTS "job_update_deactivate_policy" ON job;
+DROP POLICY IF EXISTS "job_update_recover_policy" ON job;
+
+-- 1. SELECT policy
+CREATE POLICY "job_select_policy" ON job
+    FOR SELECT
+    USING (
+        record_status = 'ACTIVE' 
+        OR 
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    );
+
+-- 2. INSERT policy (requires JOB_ADD)
+CREATE POLICY "job_insert_policy" ON job
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JOB_ADD' 
+            AND right_value = 1
+        )
+    );
+
+-- 3. UPDATE-edit policy (requires JOB_EDIT)
+CREATE POLICY "job_update_edit_policy" ON job
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JOB_EDIT' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JOB_EDIT' 
+            AND right_value = 1
+        )
+    );
+
+-- 4. UPDATE-deactivate policy (requires JOB_DEL)
+CREATE POLICY "job_update_deactivate_policy" ON job
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'JOB_DEL' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        record_status = 'INACTIVE'
+    );
+
+-- 5. UPDATE-recover policy (ADMIN/SUPERADMIN only)
+CREATE POLICY "job_update_recover_policy" ON job
+    FOR UPDATE
+    USING (
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    )
+    WITH CHECK (
+        record_status = 'ACTIVE'
+    );
+
+-- ============================================
+-- DEPARTMENT TABLE Policies
+-- ============================================
+
+-- Drop existing policies if any
+DROP POLICY IF EXISTS "department_select_policy" ON department;
+DROP POLICY IF EXISTS "department_insert_policy" ON department;
+DROP POLICY IF EXISTS "department_update_edit_policy" ON department;
+DROP POLICY IF EXISTS "department_update_deactivate_policy" ON department;
+DROP POLICY IF EXISTS "department_update_recover_policy" ON department;
+
+-- 1. SELECT policy
+CREATE POLICY "department_select_policy" ON department
+    FOR SELECT
+    USING (
+        record_status = 'ACTIVE' 
+        OR 
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    );
+
+-- 2. INSERT policy (requires DEPT_ADD)
+CREATE POLICY "department_insert_policy" ON department
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'DEPT_ADD' 
+            AND right_value = 1
+        )
+    );
+
+-- 3. UPDATE-edit policy (requires DEPT_EDIT)
+CREATE POLICY "department_update_edit_policy" ON department
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'DEPT_EDIT' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'DEPT_EDIT' 
+            AND right_value = 1
+        )
+    );
+
+-- 4. UPDATE-deactivate policy (requires DEPT_DEL)
+CREATE POLICY "department_update_deactivate_policy" ON department
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user 
+            AND right_code = 'DEPT_DEL' 
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        record_status = 'INACTIVE'
+    );
+
+-- 5. UPDATE-recover policy (ADMIN/SUPERADMIN only)
+CREATE POLICY "department_update_recover_policy" ON department
+    FOR UPDATE
+    USING (
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    )
+    WITH CHECK (
+        record_status = 'ACTIVE'
+    );
+


### PR DESCRIPTION
## PR-02: RLS Policies for jobHistory, job, and department Tables

### What this PR does:
- Creates 5 RLS policies on each table (jobHistory, job, and department) - SELECT, INSERT, UPDATE-edit, UPDATE-deactivate, UPDATE-recover
- Enforces soft-delete only on all three tables (no hard DELETE allowed)
- Restricts USER accounts to view only ACTIVE records on all tables
- Allows ADMIN/SUPERADMIN to view ALL records (including INACTIVE) on all tables
- Controls write operations based on specific rights for each table (JH_ADD/JH_EDIT/JH_DEL for jobHistory, JOB_ADD/JOB_EDIT/JOB_DEL for job, DEPT_ADD/DEPT_EDIT/DEPT_DEL for department)

### Policies Created:
Five RLS policies were created on the jobHistory, job, and department tables. The SELECT policy allows USER accounts to see only ACTIVE records while ADMIN and SUPERADMIN can see all records. The INSERT policy requires users to have the ADD right for the specific table (JH_ADD, JOB_ADD, or DEPT_ADD) set to 1. The UPDATE-edit policy requires users to have the EDIT right for the specific table (JH_EDIT, JOB_EDIT, or DEPT_EDIT) set to 1. The UPDATE-deactivate policy requires users to have the DEL right for the specific table (JH_DEL, JOB_DEL, or DEPT_DEL) set to 1 and only allows changing record_status to INACTIVE. The UPDATE-recover policy is restricted to ADMIN and SUPERADMIN only and only allows changing record_status to ACTIVE.

### Rights Required:

**jobHistory Table:**
- `JH_VIEW` - View job history records
- `JH_ADD` - Insert new job history records
- `JH_EDIT` - Edit job history information
- `JH_DEL` - Soft delete job history records

**job Table:**
- `JOB_VIEW` - View job records
- `JOB_ADD` - Insert new job records
- `JOB_EDIT` - Edit job information
- `JOB_DEL` - Soft delete job records

**department Table:**
- `DEPT_VIEW` - View department records
- `DEPT_ADD` - Insert new department records
- `DEPT_EDIT` - Edit department information
- `DEPT_DEL` - Soft delete department records

### Business Rules Enforced:
- No hard deletes on any table - only soft delete via `record_status = 'INACTIVE'`
- USER accounts cannot see INACTIVE records on any table
- ADMIN/SUPERADMIN can see and recover INACTIVE records on all tables
- Only users with proper rights can INSERT, EDIT, or DELETE on each respective table

### Dependencies:
- `get_current_user_type()` function
- `UserModule_Rights` table
- Supabase Auth `current_user`
