### PR TITLE
[DB] S2 PR-03: db/trigger-cascade-softdelete —Cascade trigger (employee → jobHistory status sync)

### DIFF
--- a/S2 PR-03/Cascade trigger (employee → jobHistory status sync)
+++ b/S2 PR-03/Cascade trigger (employee → jobHistory status sync)
@@ -1,0 +1,28 @@
+-- ============================================
+-- PR-03: Soft-Delete Cascade Trigger
+-- ============================================
+
+-- Drop trigger if it exists (clean slate)
+DROP TRIGGER IF EXISTS employee_status_cascade ON employee;
+DROP FUNCTION IF EXISTS cascade_employee_status();
+
+-- Create trigger function
+CREATE OR REPLACE FUNCTION cascade_employee_status()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- When employee becomes INACTIVE, deactivate all their job history
+    IF NEW.record_status = 'INACTIVE' AND OLD.record_status = 'ACTIVE' THEN
+        UPDATE jobHistory 
+        SET record_status = 'INACTIVE', stamp = 'CASCADED_FROM_EMPLOYEE'
+        WHERE empNo = NEW.empno;
+    
+    -- When employee becomes ACTIVE, reactivate all their job history
+    ELSIF NEW.record_status = 'ACTIVE' AND OLD.record_status = 'INACTIVE' THEN
+        UPDATE jobHistory 
+        SET record_status = 'ACTIVE', stamp = 'CASCADED_FROM_EMPLOYEE'
+        WHERE empNo = NEW.empno;
+    END IF;
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## PR-03: db/trigger-cascade-softdelete —Soft-Delete Cascade Trigger

### What this PR does:
- Creates a trigger function that automatically synchronizes employee status with their job history records
- When an employee is soft-deleted (record_status changed to INACTIVE), all related jobHistory records for that employee automatically become INACTIVE
- When an employee is recovered (record_status changed back to ACTIVE), all related jobHistory records for that employee automatically become ACTIVE
- Maintains data integrity between employee and jobHistory tables

### Trigger Created:
A trigger function named `cascade_employee_status` was created and attached to the employee table. The trigger fires AFTER an UPDATE operation on the record_status column of the employee table. When an employee's status changes from ACTIVE to INACTIVE, the function updates all jobHistory records with the matching empNo to INACTIVE. When an employee's status changes from INACTIVE to ACTIVE, the function updates all jobHistory records with the matching empNo to ACTIVE. The stamp column in jobHistory is updated to 'CASCADED_FROM_EMPLOYEE' to track the source of the change.

### Business Rules Enforced:
- Employee soft delete automatically cascades to their job history
- Employee recovery automatically restores their job history
- Prevents orphaned ACTIVE jobHistory records for INACTIVE employees
- Ensures USER accounts cannot see job history of INACTIVE employees (since jobHistory becomes INACTIVE)
- Maintains audit trail via stamp column

### Dependencies:
- employee table (with record_status column)
- jobHistory table (with empNo foreign key and record_status column)
- AFTER UPDATE trigger on employee table
