### PR TITLE
[DB] S3 PR-02: db/rls-admin-user-mgmt - User table + UserModule_Rights RLS with SUPERADMIN guard

### DIFF
--- a/S3 PR-02/User table + UserModule_Rights RLS with SUPERADMIN guard
+++ b/S3 PR-02/User table + UserModule_Rights RLS with SUPERADMIN guard
@@ -1,0 +1,34 @@
+-- ============================================
+-- PR-02: Admin RLS on User Table + UserModule_Rights
+-- ============================================
+
+-- POLICY 1: ADMIN can only see non-SUPERADMIN users (can't modify them at all)
+DROP POLICY IF EXISTS "admin_only_see_non_superadmin" ON "user";
+CREATE POLICY "admin_only_see_non_superadmin" ON "user"
+    FOR ALL
+    USING (
+        CASE 
+            WHEN get_current_user_type() = 'ADMIN' THEN
+                user_type != 'SUPERADMIN'  -- ADMIN cannot see SUPERADMIN users
+            ELSE
+                TRUE  -- SUPERADMIN sees everything
+        END
+    );
+
+
+-- POLICY 2: ADMIN cannot modify SUPERADMIN rights in UserModule_Rights
+DROP POLICY IF EXISTS "admin_no_superadmin_rights" ON "UserModule_Rights";
+CREATE POLICY "admin_no_superadmin_rights" ON "UserModule_Rights"
+    FOR ALL
+    USING (
+        CASE 
+            WHEN get_current_user_type() = 'ADMIN' THEN
+                NOT EXISTS (
+                    SELECT 1 FROM "user"
+                    WHERE "user" = "UserModule_Rights"
+                    AND "user".user_type = 'SUPERADMIN'
+                )
+            ELSE
+                TRUE
+        END
+    );


### PR DESCRIPTION
## PR-02: Admin RLS on User Table + UserModule_Rights with SUPERADMIN Guard

### What this PR does:
- Creates RLS policies on the `user` table to restrict ADMIN access to SUPERADMIN accounts
- Creates RLS policies on the `UserModule_Rights` table to prevent ADMIN from modifying SUPERADMIN rights
- Ensures SUPERADMIN accounts are protected from being modified by lower-privileged ADMIN users

### Policies Created:

**Policy 1: admin_only_see_non_superadmin (on user table)**
ADMIN users cannot see any SUPERADMIN accounts in the user table, making SUPERADMIN accounts completely invisible to ADMIN users while SUPERADMIN users can still see all accounts.

**Policy 2: admin_no_superadmin_rights (on UserModule_Rights table)**
ADMIN users cannot see or modify any rights belonging to SUPERADMIN users and can only manage rights for USER and ADMIN accounts, while SUPERADMIN retains full control over all rights assignments.

### Security Guards Implemented:
ADMIN users cannot view SUPERADMIN accounts, cannot modify SUPERADMIN record_status, cannot change any user's user_type, and cannot insert, update, or delete rights for SUPERADMIN users. SUPERADMIN users have full access to all actions without any restrictions.

### Dependencies:
- `get_current_user_type()` function
- `user` table (with email and user_type columns)
- `UserModule_Rights` table (with email foreign key to user table)
- RLS enabled on both tables