### PR TITLE
[DB] S2 PR-01: db/rls-employee -SELECT + INSERT + UPDATE (edit + deactivate + recover) policies for employee

### DIFF
--- a/S2 PR-01/employee RLS policies
+++ b/S2 PR-01/employee RLS policies
@@ -1,0 +1,88 @@
+-- ============================================
+-- PR-01: Complete employee RLS policies
+-- ============================================
+
+
+
+
+-- 1. SELECT policy
+CREATE POLICY "employee_select_policy" ON employee
+    FOR SELECT
+    USING (
+        record_status = 'ACTIVE'
+        OR
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    );
+
+
+-- 2. INSERT policy
+CREATE POLICY "employee_insert_policy" ON employee
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user
+            AND right_code = 'EMP_ADD'
+            AND right_value = 1
+        )
+    );
+
+
+-- 3. UPDATE-edit policy
+CREATE POLICY "employee_update_edit_policy" ON employee
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user
+            AND right_code = 'EMP_EDIT'
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user
+            AND right_code = 'EMP_EDIT'
+            AND right_value = 1
+        )
+    );
+
+
+-- 4. UPDATE-deactivate policy (CORRECTED - no OLD/NEW)
+CREATE POLICY "employee_update_deactivate_policy" ON employee
+    FOR UPDATE
+    USING (
+        -- User must have EMP_DEL right
+        EXISTS (
+            SELECT 1 FROM UserModule_Rights
+            WHERE email = current_user
+            AND right_code = 'EMP_DEL'
+            AND right_value = 1
+        )
+    )
+    WITH CHECK (
+        
+        record_status = 'INACTIVE'
+    );
+
+
+-- 5. UPDATE-recover policy (CORRECTED)
+CREATE POLICY "employee_update_recover_policy" ON employee
+    FOR UPDATE
+    USING (
+        
+        get_current_user_type() IN ('ADMIN', 'SUPERADMIN')
+    )
+    WITH CHECK (
+       
+        record_status = 'ACTIVE'
+    );
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## PR-01: Employee Table RLS Policies

### What this PR does:
- Creates 5 RLS policies on the `employee` table (SELECT, INSERT, UPDATE-edit, UPDATE-deactivate, UPDATE-recover)
- Enforces soft-delete only (no hard DELETE allowed)
- Restricts USER accounts to view only ACTIVE records
- Allows ADMIN/SUPERADMIN to view ALL records (including INACTIVE)
- Controls write operations based on specific rights (EMP_ADD, EMP_EDIT, EMP_DEL)

### Policies Created:
Five RLS policies were created on the employee table. The SELECT policy allows USER accounts to see only ACTIVE records while ADMIN and SUPERADMIN can see all records. The INSERT policy requires users to have the EMP_ADD right set to 1. The UPDATE-edit policy requires users to have the EMP_EDIT right set to 1. The UPDATE-deactivate policy requires users to have the EMP_DEL right set to 1 and only allows changing record_status to INACTIVE. The UPDATE-recover policy is restricted to ADMIN and SUPERADMIN only and only allows changing record_status to ACTIVE.

### Rights Required:
- `EMP_VIEW` - View employees
- `EMP_ADD` - Insert new employees
- `EMP_EDIT` - Edit employee information
- `EMP_DEL` - Soft delete employees

### Business Rules Enforced:
- No hard deletes - only soft delete via `record_status = 'INACTIVE'`
- USER accounts cannot see INACTIVE records
- ADMIN/SUPERADMIN can see and recover INACTIVE records
- Only users with proper rights can INSERT, EDIT, or DELETE

### Dependencies:
- `get_current_user_type()` function
- `UserModule_Rights` table
- Supabase Auth `current_user`
